### PR TITLE
Create core tables in database

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# **Core Stack**
+# Webdevathon
+
+## **Core Stack**
 
 ### Framework
 
@@ -31,3 +33,115 @@
 ### Image Moderation
 
 - **Amazon Rekognition** for PII and image moderation.
+
+## Data Models
+
+Our application uses the following data models to represent various entities and their relationships:
+
+### Users
+
+- Represents individual users of the application
+- Stores basic user information like email, name, and profile image
+- Connected to:
+  - Challenges (as organizers)
+  - Teams (as members and team leads)
+  - Submissions
+  - Tasks (as assignees)
+  - Notes (as authors)
+  - File Storage (for user-specific files)
+
+### Challenges
+
+- Represents hackathon events or coding challenges
+- Includes details like name, description, start and end dates
+- Connected to:
+  - Users (organizers)
+  - Teams
+  - Stages
+  - Events
+  - Resources
+  - Tags (many-to-many)
+  - Submissions
+
+### Teams
+
+- Represents groups of users participating in a challenge
+- Includes team name, role, and join date
+- Connected to:
+  - Challenges
+  - Users (members and team lead)
+  - Submissions
+  - Tasks
+  - Notes
+  - File Storage (for team-specific files)
+
+### Stages
+
+- Represents different phases or milestones within a challenge
+- Includes name, description, duration, and order
+- Connected to:
+  - Challenges
+  - Tasks
+  - Notes
+
+### Tasks
+
+- Represents specific activities or to-dos within a stage
+- Includes details like name, status, estimate, due date
+- Connected to:
+  - Stages
+  - Teams
+  - Users (assignees)
+
+### Submissions
+
+- Represents project submissions for challenges
+- Includes details like title, description, repository link
+- Connected to:
+  - Challenges
+  - Teams
+  - Users (individual submissions)
+  - Tags (many-to-many)
+
+### Tags
+
+- Represents labels or categories for challenges and submissions
+- Includes name and description
+- Connected to:
+  - Challenges (many-to-many)
+  - Submissions (many-to-many)
+
+### Events
+
+- Represents specific events within a challenge (e.g., workshops, presentations)
+- Includes name, description, start and end dates
+- Connected to:
+  - Challenges
+
+### Resources
+
+- Represents additional materials or links related to a challenge
+- Includes title, URL, type, and description
+- Connected to:
+  - Challenges
+
+### Notes
+
+- Represents text notes or comments
+- Can be associated with challenges, stages, or teams
+- Connected to:
+  - Challenges
+  - Stages
+  - Teams
+  - Users (authors)
+
+### File Storage
+
+- Represents files uploaded to the system
+- Can be associated with challenges, teams, or users
+- Connected to:
+  - Challenges
+  - Teams
+  - Users
+
+These models form the backbone of our application, allowing for a flexible and comprehensive representation of hackathons, teams, and all related activities and resources.

--- a/lib/db/migrations/0005_heavy_proteus.sql
+++ b/lib/db/migrations/0005_heavy_proteus.sql
@@ -1,0 +1,312 @@
+CREATE TABLE IF NOT EXISTS "challenges" (
+	"id" text PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" text NOT NULL,
+	"description" text,
+	"start_date" timestamp (6) with time zone NOT NULL,
+	"end_date" timestamp (6) with time zone NOT NULL,
+	"organizer_id" text NOT NULL,
+	"created" timestamp (6) with time zone DEFAULT now() NOT NULL,
+	"updated" timestamp (6) with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "events" (
+	"id" text PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"challenge_id" text NOT NULL,
+	"name" text NOT NULL,
+	"description" text,
+	"start_date" timestamp (6) with time zone NOT NULL,
+	"end_date" timestamp (6) with time zone NOT NULL,
+	"created" timestamp (6) with time zone DEFAULT now() NOT NULL,
+	"updated" timestamp (6) with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "file_storage" (
+	"file_id" text PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"challenge_id" text,
+	"team_id" text,
+	"user_id" text,
+	"file_name" text NOT NULL,
+	"bucket_name" text NOT NULL,
+	"file_type" text NOT NULL,
+	"created" timestamp (6) with time zone DEFAULT now() NOT NULL,
+	"updated" timestamp (6) with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "notes" (
+	"id" text PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"challenge_id" text,
+	"stage_id" text,
+	"team_id" text,
+	"author_id" text NOT NULL,
+	"content" text NOT NULL,
+	"created" timestamp (6) with time zone DEFAULT now() NOT NULL,
+	"updated" timestamp (6) with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "resources" (
+	"resource_id" text PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"challenge_id" text,
+	"title" text NOT NULL,
+	"url" text,
+	"resource_type" text NOT NULL,
+	"description" text,
+	"created" timestamp (6) with time zone DEFAULT now() NOT NULL,
+	"updated" timestamp (6) with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "stages" (
+	"id" text PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"challenge_id" text NOT NULL,
+	"name" text NOT NULL,
+	"description" text,
+	"duration_minutes" integer,
+	"order" integer DEFAULT 0 NOT NULL,
+	"created" timestamp (6) with time zone DEFAULT now() NOT NULL,
+	"updated" timestamp (6) with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "submissions" (
+	"id" text PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"challenge_id" text NOT NULL,
+	"team_id" text,
+	"user_id" text,
+	"submission_title" text NOT NULL,
+	"description" text,
+	"repo_link" text,
+	"video_link" text,
+	"submitted_at" timestamp (6) with time zone DEFAULT now() NOT NULL,
+	"created" timestamp (6) with time zone DEFAULT now() NOT NULL,
+	"updated" timestamp (6) with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "tags" (
+	"tag_id" text PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" text NOT NULL,
+	"description" text,
+	"created" timestamp (6) with time zone DEFAULT now() NOT NULL,
+	"updated" timestamp (6) with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "tags_name_unique" UNIQUE("name")
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "tags_challenges" (
+	"challenge_id" text NOT NULL,
+	"tag_id" text NOT NULL,
+	"created" timestamp (6) with time zone DEFAULT now() NOT NULL,
+	"updated" timestamp (6) with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "tags_challenges_challenge_id_tag_id_pk" PRIMARY KEY("challenge_id","tag_id")
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "tags_submissions" (
+	"submission_id" text NOT NULL,
+	"tag_id" text NOT NULL,
+	"created" timestamp (6) with time zone DEFAULT now() NOT NULL,
+	"updated" timestamp (6) with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "tags_submissions_submission_id_tag_id_pk" PRIMARY KEY("submission_id","tag_id")
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "tasks" (
+	"id" text PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"stage_id" text NOT NULL,
+	"team_id" text,
+	"assigned_to" text,
+	"estimate_minutes" integer DEFAULT 0,
+	"task_name" text NOT NULL,
+	"status" text DEFAULT 'not_started' NOT NULL,
+	"due_date" timestamp (6) with time zone,
+	"completed_at" timestamp (6) with time zone,
+	"created" timestamp (6) with time zone DEFAULT now() NOT NULL,
+	"updated" timestamp (6) with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "teams" (
+	"id" text PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" text NOT NULL,
+	"joined_at" timestamp (6) with time zone DEFAULT now() NOT NULL,
+	"team_role" text,
+	"challenge_id" text NOT NULL,
+	"team_lead_id" text NOT NULL,
+	"created" timestamp (6) with time zone DEFAULT now() NOT NULL,
+	"updated" timestamp (6) with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "challenges" ADD CONSTRAINT "challenges_organizer_id_users_id_fk" FOREIGN KEY ("organizer_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "events" ADD CONSTRAINT "events_challenge_id_challenges_id_fk" FOREIGN KEY ("challenge_id") REFERENCES "public"."challenges"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "file_storage" ADD CONSTRAINT "file_storage_challenge_id_challenges_id_fk" FOREIGN KEY ("challenge_id") REFERENCES "public"."challenges"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "file_storage" ADD CONSTRAINT "file_storage_team_id_teams_id_fk" FOREIGN KEY ("team_id") REFERENCES "public"."teams"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "file_storage" ADD CONSTRAINT "file_storage_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "notes" ADD CONSTRAINT "notes_challenge_id_challenges_id_fk" FOREIGN KEY ("challenge_id") REFERENCES "public"."challenges"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "notes" ADD CONSTRAINT "notes_stage_id_stages_id_fk" FOREIGN KEY ("stage_id") REFERENCES "public"."stages"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "notes" ADD CONSTRAINT "notes_team_id_teams_id_fk" FOREIGN KEY ("team_id") REFERENCES "public"."teams"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "notes" ADD CONSTRAINT "notes_author_id_users_id_fk" FOREIGN KEY ("author_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "resources" ADD CONSTRAINT "resources_challenge_id_challenges_id_fk" FOREIGN KEY ("challenge_id") REFERENCES "public"."challenges"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "stages" ADD CONSTRAINT "stages_challenge_id_challenges_id_fk" FOREIGN KEY ("challenge_id") REFERENCES "public"."challenges"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "submissions" ADD CONSTRAINT "submissions_challenge_id_challenges_id_fk" FOREIGN KEY ("challenge_id") REFERENCES "public"."challenges"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "submissions" ADD CONSTRAINT "submissions_team_id_teams_id_fk" FOREIGN KEY ("team_id") REFERENCES "public"."teams"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "submissions" ADD CONSTRAINT "submissions_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "tags_challenges" ADD CONSTRAINT "tags_challenges_challenge_id_challenges_id_fk" FOREIGN KEY ("challenge_id") REFERENCES "public"."challenges"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "tags_challenges" ADD CONSTRAINT "tags_challenges_tag_id_tags_tag_id_fk" FOREIGN KEY ("tag_id") REFERENCES "public"."tags"("tag_id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "tags_submissions" ADD CONSTRAINT "tags_submissions_submission_id_submissions_id_fk" FOREIGN KEY ("submission_id") REFERENCES "public"."submissions"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "tags_submissions" ADD CONSTRAINT "tags_submissions_tag_id_tags_tag_id_fk" FOREIGN KEY ("tag_id") REFERENCES "public"."tags"("tag_id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "tasks" ADD CONSTRAINT "tasks_stage_id_stages_id_fk" FOREIGN KEY ("stage_id") REFERENCES "public"."stages"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "tasks" ADD CONSTRAINT "tasks_team_id_teams_id_fk" FOREIGN KEY ("team_id") REFERENCES "public"."teams"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "tasks" ADD CONSTRAINT "tasks_assigned_to_users_id_fk" FOREIGN KEY ("assigned_to") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "teams" ADD CONSTRAINT "teams_challenge_id_challenges_id_fk" FOREIGN KEY ("challenge_id") REFERENCES "public"."challenges"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "teams" ADD CONSTRAINT "teams_team_lead_id_users_id_fk" FOREIGN KEY ("team_lead_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "challenges_organizer_id_idx" ON "challenges" USING btree ("organizer_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "challenges_start_date_idx" ON "challenges" USING btree ("start_date");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "events_challenge_id_idx" ON "events" USING btree ("challenge_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "events_start_date_idx" ON "events" USING btree ("start_date");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "events_end_date_idx" ON "events" USING btree ("end_date");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "file_storage_challenge_id_idx" ON "file_storage" USING btree ("challenge_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "file_storage_team_id_idx" ON "file_storage" USING btree ("team_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "file_storage_user_id_idx" ON "file_storage" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "notes_challenge_id_idx" ON "notes" USING btree ("challenge_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "notes_stage_id_idx" ON "notes" USING btree ("stage_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "notes_team_id_idx" ON "notes" USING btree ("team_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "notes_author_id_idx" ON "notes" USING btree ("author_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "resources_challenge_id_idx" ON "resources" USING btree ("challenge_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "stages_challenge_id_idx" ON "stages" USING btree ("challenge_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "stages_order_idx" ON "stages" USING btree ("order");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "submissions_challenge_id_idx" ON "submissions" USING btree ("challenge_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "submissions_team_id_idx" ON "submissions" USING btree ("team_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "submissions_user_id_idx" ON "submissions" USING btree ("user_id");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "submissions_challenge_team_unique" ON "submissions" USING btree ("challenge_id","team_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "tags_challenges_challenge_id_idx" ON "tags_challenges" USING btree ("challenge_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "tags_challenges_tag_id_idx" ON "tags_challenges" USING btree ("tag_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "tags_submissions_submission_id_idx" ON "tags_submissions" USING btree ("submission_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "tags_submissions_tag_id_idx" ON "tags_submissions" USING btree ("tag_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "tasks_stage_id_idx" ON "tasks" USING btree ("stage_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "tasks_team_id_idx" ON "tasks" USING btree ("team_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "tasks_assigned_to_idx" ON "tasks" USING btree ("assigned_to");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "teams_challenge_id_idx" ON "teams" USING btree ("challenge_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "teams_team_lead_id_idx" ON "teams" USING btree ("team_lead_id");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "unique_team_name_per_challenge" ON "teams" USING btree ("challenge_id","name");--> statement-breakpoint
+
+DO $$ 
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 
+    FROM information_schema.table_constraints 
+    WHERE constraint_name = 'check_end_date_after_start_date'
+      AND table_name = 'challenges'
+  ) THEN
+    ALTER TABLE challenges
+    ADD CONSTRAINT check_end_date_after_start_date
+    CHECK (end_date > start_date);
+  END IF;
+END $$;

--- a/lib/db/migrations/0006_wide_rhino.sql
+++ b/lib/db/migrations/0006_wide_rhino.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "challenges" ADD COLUMN "public" boolean DEFAULT true NOT NULL;

--- a/lib/db/migrations/meta/0005_snapshot.json
+++ b/lib/db/migrations/meta/0005_snapshot.json
@@ -1,0 +1,1595 @@
+{
+  "id": "3b7a0d0c-2ba9-4520-9336-6abffe11c317",
+  "prevId": "640bc9a2-99a7-4a76-93df-a2245274649a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.challenges": {
+      "name": "challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizer_id": {
+          "name": "organizer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "challenges_organizer_id_idx": {
+          "name": "challenges_organizer_id_idx",
+          "columns": [
+            {
+              "expression": "organizer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "challenges_start_date_idx": {
+          "name": "challenges_start_date_idx",
+          "columns": [
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "challenges_organizer_id_users_id_fk": {
+          "name": "challenges_organizer_id_users_id_fk",
+          "tableFrom": "challenges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "organizer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "events_challenge_id_idx": {
+          "name": "events_challenge_id_idx",
+          "columns": [
+            {
+              "expression": "challenge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_start_date_idx": {
+          "name": "events_start_date_idx",
+          "columns": [
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_end_date_idx": {
+          "name": "events_end_date_idx",
+          "columns": [
+            {
+              "expression": "end_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_challenge_id_challenges_id_fk": {
+          "name": "events_challenge_id_challenges_id_fk",
+          "tableFrom": "events",
+          "tableTo": "challenges",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.file_storage": {
+      "name": "file_storage",
+      "schema": "",
+      "columns": {
+        "file_id": {
+          "name": "file_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_name": {
+          "name": "bucket_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "file_storage_challenge_id_idx": {
+          "name": "file_storage_challenge_id_idx",
+          "columns": [
+            {
+              "expression": "challenge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "file_storage_team_id_idx": {
+          "name": "file_storage_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "file_storage_user_id_idx": {
+          "name": "file_storage_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "file_storage_challenge_id_challenges_id_fk": {
+          "name": "file_storage_challenge_id_challenges_id_fk",
+          "tableFrom": "file_storage",
+          "tableTo": "challenges",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "file_storage_team_id_teams_id_fk": {
+          "name": "file_storage_team_id_teams_id_fk",
+          "tableFrom": "file_storage",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "file_storage_user_id_users_id_fk": {
+          "name": "file_storage_user_id_users_id_fk",
+          "tableFrom": "file_storage",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.notes": {
+      "name": "notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notes_challenge_id_idx": {
+          "name": "notes_challenge_id_idx",
+          "columns": [
+            {
+              "expression": "challenge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notes_stage_id_idx": {
+          "name": "notes_stage_id_idx",
+          "columns": [
+            {
+              "expression": "stage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notes_team_id_idx": {
+          "name": "notes_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notes_author_id_idx": {
+          "name": "notes_author_id_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notes_challenge_id_challenges_id_fk": {
+          "name": "notes_challenge_id_challenges_id_fk",
+          "tableFrom": "notes",
+          "tableTo": "challenges",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notes_stage_id_stages_id_fk": {
+          "name": "notes_stage_id_stages_id_fk",
+          "tableFrom": "notes",
+          "tableTo": "stages",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notes_team_id_teams_id_fk": {
+          "name": "notes_team_id_teams_id_fk",
+          "tableFrom": "notes",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notes_author_id_users_id_fk": {
+          "name": "notes_author_id_users_id_fk",
+          "tableFrom": "notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.resources": {
+      "name": "resources",
+      "schema": "",
+      "columns": {
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "resources_challenge_id_idx": {
+          "name": "resources_challenge_id_idx",
+          "columns": [
+            {
+              "expression": "challenge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "resources_challenge_id_challenges_id_fk": {
+          "name": "resources_challenge_id_challenges_id_fk",
+          "tableFrom": "resources",
+          "tableTo": "challenges",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.stages": {
+      "name": "stages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stages_challenge_id_idx": {
+          "name": "stages_challenge_id_idx",
+          "columns": [
+            {
+              "expression": "challenge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stages_order_idx": {
+          "name": "stages_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stages_challenge_id_challenges_id_fk": {
+          "name": "stages_challenge_id_challenges_id_fk",
+          "tableFrom": "stages",
+          "tableTo": "challenges",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.submissions": {
+      "name": "submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_title": {
+          "name": "submission_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_link": {
+          "name": "repo_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "video_link": {
+          "name": "video_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "submissions_challenge_id_idx": {
+          "name": "submissions_challenge_id_idx",
+          "columns": [
+            {
+              "expression": "challenge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "submissions_team_id_idx": {
+          "name": "submissions_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "submissions_user_id_idx": {
+          "name": "submissions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "submissions_challenge_team_unique": {
+          "name": "submissions_challenge_team_unique",
+          "columns": [
+            {
+              "expression": "challenge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "submissions_challenge_id_challenges_id_fk": {
+          "name": "submissions_challenge_id_challenges_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "challenges",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "submissions_team_id_teams_id_fk": {
+          "name": "submissions_team_id_teams_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "submissions_user_id_users_id_fk": {
+          "name": "submissions_user_id_users_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "public.tags_challenges": {
+      "name": "tags_challenges",
+      "schema": "",
+      "columns": {
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tags_challenges_challenge_id_idx": {
+          "name": "tags_challenges_challenge_id_idx",
+          "columns": [
+            {
+              "expression": "challenge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tags_challenges_tag_id_idx": {
+          "name": "tags_challenges_tag_id_idx",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tags_challenges_challenge_id_challenges_id_fk": {
+          "name": "tags_challenges_challenge_id_challenges_id_fk",
+          "tableFrom": "tags_challenges",
+          "tableTo": "challenges",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tags_challenges_tag_id_tags_tag_id_fk": {
+          "name": "tags_challenges_tag_id_tags_tag_id_fk",
+          "tableFrom": "tags_challenges",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "tag_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tags_challenges_challenge_id_tag_id_pk": {
+          "name": "tags_challenges_challenge_id_tag_id_pk",
+          "columns": [
+            "challenge_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.tags_submissions": {
+      "name": "tags_submissions",
+      "schema": "",
+      "columns": {
+        "submission_id": {
+          "name": "submission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tags_submissions_submission_id_idx": {
+          "name": "tags_submissions_submission_id_idx",
+          "columns": [
+            {
+              "expression": "submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tags_submissions_tag_id_idx": {
+          "name": "tags_submissions_tag_id_idx",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tags_submissions_submission_id_submissions_id_fk": {
+          "name": "tags_submissions_submission_id_submissions_id_fk",
+          "tableFrom": "tags_submissions",
+          "tableTo": "submissions",
+          "columnsFrom": [
+            "submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tags_submissions_tag_id_tags_tag_id_fk": {
+          "name": "tags_submissions_tag_id_tags_tag_id_fk",
+          "tableFrom": "tags_submissions",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "tag_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tags_submissions_submission_id_tag_id_pk": {
+          "name": "tags_submissions_submission_id_tag_id_pk",
+          "columns": [
+            "submission_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_to": {
+          "name": "assigned_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimate_minutes": {
+          "name": "estimate_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "task_name": {
+          "name": "task_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tasks_stage_id_idx": {
+          "name": "tasks_stage_id_idx",
+          "columns": [
+            {
+              "expression": "stage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_team_id_idx": {
+          "name": "tasks_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_assigned_to_idx": {
+          "name": "tasks_assigned_to_idx",
+          "columns": [
+            {
+              "expression": "assigned_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tasks_stage_id_stages_id_fk": {
+          "name": "tasks_stage_id_stages_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "stages",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tasks_team_id_teams_id_fk": {
+          "name": "tasks_team_id_teams_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tasks_assigned_to_users_id_fk": {
+          "name": "tasks_assigned_to_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "team_role": {
+          "name": "team_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_lead_id": {
+          "name": "team_lead_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "teams_challenge_id_idx": {
+          "name": "teams_challenge_id_idx",
+          "columns": [
+            {
+              "expression": "challenge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "teams_team_lead_id_idx": {
+          "name": "teams_team_lead_id_idx",
+          "columns": [
+            {
+              "expression": "team_lead_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_team_name_per_challenge": {
+          "name": "unique_team_name_per_challenge",
+          "columns": [
+            {
+              "expression": "challenge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "teams_challenge_id_challenges_id_fk": {
+          "name": "teams_challenge_id_challenges_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "challenges",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "teams_team_lead_id_users_id_fk": {
+          "name": "teams_team_lead_id_users_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "users",
+          "columnsFrom": [
+            "team_lead_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clerk_id": {
+          "name": "clerk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_image_url": {
+          "name": "profile_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_clerk_id_unique": {
+          "name": "users_clerk_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clerk_id"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/lib/db/migrations/meta/0006_snapshot.json
+++ b/lib/db/migrations/meta/0006_snapshot.json
@@ -1,0 +1,1602 @@
+{
+  "id": "9c0c1eb1-8abd-4659-af17-975e5f30333c",
+  "prevId": "3b7a0d0c-2ba9-4520-9336-6abffe11c317",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.challenges": {
+      "name": "challenges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizer_id": {
+          "name": "organizer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "challenges_organizer_id_idx": {
+          "name": "challenges_organizer_id_idx",
+          "columns": [
+            {
+              "expression": "organizer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "challenges_start_date_idx": {
+          "name": "challenges_start_date_idx",
+          "columns": [
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "challenges_organizer_id_users_id_fk": {
+          "name": "challenges_organizer_id_users_id_fk",
+          "tableFrom": "challenges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "organizer_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "events_challenge_id_idx": {
+          "name": "events_challenge_id_idx",
+          "columns": [
+            {
+              "expression": "challenge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_start_date_idx": {
+          "name": "events_start_date_idx",
+          "columns": [
+            {
+              "expression": "start_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_end_date_idx": {
+          "name": "events_end_date_idx",
+          "columns": [
+            {
+              "expression": "end_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_challenge_id_challenges_id_fk": {
+          "name": "events_challenge_id_challenges_id_fk",
+          "tableFrom": "events",
+          "tableTo": "challenges",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.file_storage": {
+      "name": "file_storage",
+      "schema": "",
+      "columns": {
+        "file_id": {
+          "name": "file_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_name": {
+          "name": "bucket_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "file_storage_challenge_id_idx": {
+          "name": "file_storage_challenge_id_idx",
+          "columns": [
+            {
+              "expression": "challenge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "file_storage_team_id_idx": {
+          "name": "file_storage_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "file_storage_user_id_idx": {
+          "name": "file_storage_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "file_storage_challenge_id_challenges_id_fk": {
+          "name": "file_storage_challenge_id_challenges_id_fk",
+          "tableFrom": "file_storage",
+          "tableTo": "challenges",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "file_storage_team_id_teams_id_fk": {
+          "name": "file_storage_team_id_teams_id_fk",
+          "tableFrom": "file_storage",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "file_storage_user_id_users_id_fk": {
+          "name": "file_storage_user_id_users_id_fk",
+          "tableFrom": "file_storage",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.notes": {
+      "name": "notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notes_challenge_id_idx": {
+          "name": "notes_challenge_id_idx",
+          "columns": [
+            {
+              "expression": "challenge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notes_stage_id_idx": {
+          "name": "notes_stage_id_idx",
+          "columns": [
+            {
+              "expression": "stage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notes_team_id_idx": {
+          "name": "notes_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "notes_author_id_idx": {
+          "name": "notes_author_id_idx",
+          "columns": [
+            {
+              "expression": "author_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notes_challenge_id_challenges_id_fk": {
+          "name": "notes_challenge_id_challenges_id_fk",
+          "tableFrom": "notes",
+          "tableTo": "challenges",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notes_stage_id_stages_id_fk": {
+          "name": "notes_stage_id_stages_id_fk",
+          "tableFrom": "notes",
+          "tableTo": "stages",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notes_team_id_teams_id_fk": {
+          "name": "notes_team_id_teams_id_fk",
+          "tableFrom": "notes",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notes_author_id_users_id_fk": {
+          "name": "notes_author_id_users_id_fk",
+          "tableFrom": "notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.resources": {
+      "name": "resources",
+      "schema": "",
+      "columns": {
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "resources_challenge_id_idx": {
+          "name": "resources_challenge_id_idx",
+          "columns": [
+            {
+              "expression": "challenge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "resources_challenge_id_challenges_id_fk": {
+          "name": "resources_challenge_id_challenges_id_fk",
+          "tableFrom": "resources",
+          "tableTo": "challenges",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.stages": {
+      "name": "stages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stages_challenge_id_idx": {
+          "name": "stages_challenge_id_idx",
+          "columns": [
+            {
+              "expression": "challenge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stages_order_idx": {
+          "name": "stages_order_idx",
+          "columns": [
+            {
+              "expression": "order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stages_challenge_id_challenges_id_fk": {
+          "name": "stages_challenge_id_challenges_id_fk",
+          "tableFrom": "stages",
+          "tableTo": "challenges",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.submissions": {
+      "name": "submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_title": {
+          "name": "submission_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repo_link": {
+          "name": "repo_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "video_link": {
+          "name": "video_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "submissions_challenge_id_idx": {
+          "name": "submissions_challenge_id_idx",
+          "columns": [
+            {
+              "expression": "challenge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "submissions_team_id_idx": {
+          "name": "submissions_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "submissions_user_id_idx": {
+          "name": "submissions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "submissions_challenge_team_unique": {
+          "name": "submissions_challenge_team_unique",
+          "columns": [
+            {
+              "expression": "challenge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "submissions_challenge_id_challenges_id_fk": {
+          "name": "submissions_challenge_id_challenges_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "challenges",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "submissions_team_id_teams_id_fk": {
+          "name": "submissions_team_id_teams_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "submissions_user_id_users_id_fk": {
+          "name": "submissions_user_id_users_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      }
+    },
+    "public.tags_challenges": {
+      "name": "tags_challenges",
+      "schema": "",
+      "columns": {
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tags_challenges_challenge_id_idx": {
+          "name": "tags_challenges_challenge_id_idx",
+          "columns": [
+            {
+              "expression": "challenge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tags_challenges_tag_id_idx": {
+          "name": "tags_challenges_tag_id_idx",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tags_challenges_challenge_id_challenges_id_fk": {
+          "name": "tags_challenges_challenge_id_challenges_id_fk",
+          "tableFrom": "tags_challenges",
+          "tableTo": "challenges",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tags_challenges_tag_id_tags_tag_id_fk": {
+          "name": "tags_challenges_tag_id_tags_tag_id_fk",
+          "tableFrom": "tags_challenges",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "tag_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tags_challenges_challenge_id_tag_id_pk": {
+          "name": "tags_challenges_challenge_id_tag_id_pk",
+          "columns": [
+            "challenge_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.tags_submissions": {
+      "name": "tags_submissions",
+      "schema": "",
+      "columns": {
+        "submission_id": {
+          "name": "submission_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tags_submissions_submission_id_idx": {
+          "name": "tags_submissions_submission_id_idx",
+          "columns": [
+            {
+              "expression": "submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tags_submissions_tag_id_idx": {
+          "name": "tags_submissions_tag_id_idx",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tags_submissions_submission_id_submissions_id_fk": {
+          "name": "tags_submissions_submission_id_submissions_id_fk",
+          "tableFrom": "tags_submissions",
+          "tableTo": "submissions",
+          "columnsFrom": [
+            "submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tags_submissions_tag_id_tags_tag_id_fk": {
+          "name": "tags_submissions_tag_id_tags_tag_id_fk",
+          "tableFrom": "tags_submissions",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "tag_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "tags_submissions_submission_id_tag_id_pk": {
+          "name": "tags_submissions_submission_id_tag_id_pk",
+          "columns": [
+            "submission_id",
+            "tag_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_to": {
+          "name": "assigned_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimate_minutes": {
+          "name": "estimate_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "task_name": {
+          "name": "task_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_started'"
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tasks_stage_id_idx": {
+          "name": "tasks_stage_id_idx",
+          "columns": [
+            {
+              "expression": "stage_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_team_id_idx": {
+          "name": "tasks_team_id_idx",
+          "columns": [
+            {
+              "expression": "team_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasks_assigned_to_idx": {
+          "name": "tasks_assigned_to_idx",
+          "columns": [
+            {
+              "expression": "assigned_to",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tasks_stage_id_stages_id_fk": {
+          "name": "tasks_stage_id_stages_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "stages",
+          "columnsFrom": [
+            "stage_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tasks_team_id_teams_id_fk": {
+          "name": "tasks_team_id_teams_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tasks_assigned_to_users_id_fk": {
+          "name": "tasks_assigned_to_users_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_to"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "team_role": {
+          "name": "team_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "challenge_id": {
+          "name": "challenge_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_lead_id": {
+          "name": "team_lead_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "teams_challenge_id_idx": {
+          "name": "teams_challenge_id_idx",
+          "columns": [
+            {
+              "expression": "challenge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "teams_team_lead_id_idx": {
+          "name": "teams_team_lead_id_idx",
+          "columns": [
+            {
+              "expression": "team_lead_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_team_name_per_challenge": {
+          "name": "unique_team_name_per_challenge",
+          "columns": [
+            {
+              "expression": "challenge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "teams_challenge_id_challenges_id_fk": {
+          "name": "teams_challenge_id_challenges_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "challenges",
+          "columnsFrom": [
+            "challenge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "teams_team_lead_id_users_id_fk": {
+          "name": "teams_team_lead_id_users_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "users",
+          "columnsFrom": [
+            "team_lead_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clerk_id": {
+          "name": "clerk_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_image_url": {
+          "name": "profile_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp (6) with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_clerk_id_unique": {
+          "name": "users_clerk_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clerk_id"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/lib/db/migrations/meta/_journal.json
+++ b/lib/db/migrations/meta/_journal.json
@@ -36,6 +36,20 @@
       "when": 1728531257122,
       "tag": "0004_red_newton_destine",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1728616187243,
+      "tag": "0005_heavy_proteus",
+      "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1728616653051,
+      "tag": "0006_wide_rhino",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema/challenges.ts
+++ b/lib/db/schema/challenges.ts
@@ -1,0 +1,76 @@
+import { boolean, index, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+
+import { createInsertSchema } from 'drizzle-zod';
+import { events } from './events';
+import { fileStorage } from './file-storage';
+import { notes } from './notes';
+import { relations } from 'drizzle-orm';
+import { resources } from './resources';
+import { sql } from 'drizzle-orm';
+import { stages } from './stages';
+import { tagsChallenges } from './tags-challenges';
+import { teams } from './teams';
+import { users } from './users';
+
+export const challenges = pgTable(
+  'challenges',
+  {
+    id: text('id')
+      .primaryKey()
+      .notNull()
+      .default(sql`gen_random_uuid()`),
+    name: text('name').notNull(),
+    description: text('description'),
+    public: boolean('public').notNull().default(true),
+    startDate: timestamp('start_date', {
+      precision: 6,
+      withTimezone: true
+    }).notNull(),
+    endDate: timestamp('end_date', {
+      precision: 6,
+      withTimezone: true
+    }).notNull(),
+    organizerId: text('organizer_id')
+      .notNull()
+      .references(() => users.id),
+    created: timestamp('created', { precision: 6, withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updated: timestamp('updated', { precision: 6, withTimezone: true })
+      .defaultNow()
+      .notNull()
+      .$onUpdate(() => new Date())
+  },
+  (challenges) => ({
+    organizerIdIndex: index('challenges_organizer_id_idx').on(
+      challenges.organizerId
+    ),
+    startDateIndex: index('challenges_start_date_idx').on(challenges.startDate)
+  })
+);
+
+export const challengesRelations = relations(challenges, ({ one, many }) => ({
+  events: many(events),
+  files: many(fileStorage),
+  organizer: one(users, {
+    fields: [challenges.organizerId],
+    references: [users.id]
+  }),
+  notes: many(notes),
+  resources: many(resources),
+  stages: many(stages),
+  tags: many(tagsChallenges),
+  teams: many(teams)
+}));
+
+export const insertChallengeSchema = createInsertSchema(challenges).omit({
+  created: true,
+  updated: true
+});
+
+export const updateChallengeSchema = createInsertSchema(challenges).omit({
+  created: true,
+  updated: true
+});
+
+export type ChallengeType = typeof challenges.$inferSelect;

--- a/lib/db/schema/events.ts
+++ b/lib/db/schema/events.ts
@@ -1,0 +1,60 @@
+import { index, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+
+import { challenges } from './challenges';
+import { createInsertSchema } from 'drizzle-zod';
+import { relations } from 'drizzle-orm';
+import { sql } from 'drizzle-orm';
+
+export const events = pgTable(
+  'events',
+  {
+    id: text('id')
+      .primaryKey()
+      .notNull()
+      .default(sql`gen_random_uuid()`),
+    challengeId: text('challenge_id')
+      .notNull()
+      .references(() => challenges.id),
+    name: text('name').notNull(),
+    description: text('description'),
+    startDate: timestamp('start_date', {
+      precision: 6,
+      withTimezone: true
+    }).notNull(),
+    endDate: timestamp('end_date', {
+      precision: 6,
+      withTimezone: true
+    }).notNull(),
+    created: timestamp('created', { precision: 6, withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updated: timestamp('updated', { precision: 6, withTimezone: true })
+      .defaultNow()
+      .notNull()
+      .$onUpdate(() => new Date())
+  },
+  (events) => ({
+    challengeIdIndex: index('events_challenge_id_idx').on(events.challengeId),
+    startDateIndex: index('events_start_date_idx').on(events.startDate),
+    endDateIndex: index('events_end_date_idx').on(events.endDate)
+  })
+);
+
+export const eventsRelations = relations(events, ({ one }) => ({
+  challenge: one(challenges, {
+    fields: [events.challengeId],
+    references: [challenges.id]
+  })
+}));
+
+export const insertEventSchema = createInsertSchema(events).omit({
+  created: true,
+  updated: true
+});
+
+export const updateEventSchema = createInsertSchema(events).omit({
+  created: true,
+  updated: true
+});
+
+export type EventType = typeof events.$inferSelect;

--- a/lib/db/schema/file-storage.ts
+++ b/lib/db/schema/file-storage.ts
@@ -1,0 +1,58 @@
+import { index, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+import { relations, sql } from 'drizzle-orm';
+
+import { challenges } from './challenges';
+import { createInsertSchema } from 'drizzle-zod';
+import { teams } from './teams';
+import { users } from './users';
+
+export const fileStorage = pgTable(
+  'file_storage',
+  {
+    fileId: text('file_id')
+      .primaryKey()
+      .notNull()
+      .default(sql`gen_random_uuid()`),
+    challengeId: text('challenge_id').references(() => challenges.id),
+    teamId: text('team_id').references(() => teams.id),
+    userId: text('user_id').references(() => users.id),
+    fileName: text('file_name').notNull(),
+    bucketName: text('bucket_name').notNull(),
+    fileType: text('file_type').notNull(), // "image", "video", "document", etc.
+    created: timestamp('created', { precision: 6, withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updated: timestamp('updated', { precision: 6, withTimezone: true })
+      .defaultNow()
+      .notNull()
+      .$onUpdate(() => new Date())
+  },
+  (fileStorage) => ({
+    challengeIdIndex: index('file_storage_challenge_id_idx').on(
+      fileStorage.challengeId
+    ),
+    teamIdIndex: index('file_storage_team_id_idx').on(fileStorage.teamId),
+    userIdIndex: index('file_storage_user_id_idx').on(fileStorage.userId)
+  })
+);
+
+export const fileStorageRelations = relations(fileStorage, ({ one }) => ({
+  challenge: one(challenges, {
+    fields: [fileStorage.challengeId],
+    references: [challenges.id]
+  }),
+  team: one(teams, { fields: [fileStorage.teamId], references: [teams.id] }),
+  user: one(users, { fields: [fileStorage.userId], references: [users.id] })
+}));
+
+export const insertFileSchema = createInsertSchema(fileStorage).omit({
+  created: true,
+  updated: true
+});
+
+export const updateFileSchema = createInsertSchema(fileStorage).omit({
+  created: true,
+  updated: true
+});
+
+export type FileStorageType = typeof fileStorage.$inferSelect;

--- a/lib/db/schema/index.ts
+++ b/lib/db/schema/index.ts
@@ -1,1 +1,13 @@
-export { users } from './users';
+export { challenges, challengesRelations } from './challenges';
+export { events, eventsRelations } from './events';
+export { fileStorage, fileStorageRelations } from './file-storage';
+export { notes, notesRelations } from './notes';
+export { resources, resourcesRelations } from './resources';
+export { stages, stagesRelations } from './stages';
+export { submissions, submissionsRelations } from './submissions';
+export { tagsChallenges, tagsChallengesRelations } from './tags-challenges';
+export { tagsSubmissions, tagsSubmissionsRelations } from './tags-submissions';
+export { tags, tagsRelations } from './tags';
+export { tasks, tasksRelations } from './tasks';
+export { teams, teamsRelations } from './teams';
+export { users, usersRelations } from './users';

--- a/lib/db/schema/notes.ts
+++ b/lib/db/schema/notes.ts
@@ -1,0 +1,61 @@
+import { index, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+
+import { challenges } from './challenges';
+import { createInsertSchema } from 'drizzle-zod';
+import { relations } from 'drizzle-orm';
+import { sql } from 'drizzle-orm';
+import { stages } from './stages';
+import { teams } from './teams';
+import { users } from './users';
+
+export const notes = pgTable(
+  'notes',
+  {
+    id: text('id')
+      .primaryKey()
+      .notNull()
+      .default(sql`gen_random_uuid()`),
+    challengeId: text('challenge_id').references(() => challenges.id),
+    stageId: text('stage_id').references(() => stages.id),
+    teamId: text('team_id').references(() => teams.id),
+    authorId: text('author_id')
+      .notNull()
+      .references(() => users.id),
+    content: text('content').notNull(),
+    created: timestamp('created', { precision: 6, withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updated: timestamp('updated', { precision: 6, withTimezone: true })
+      .defaultNow()
+      .notNull()
+      .$onUpdate(() => new Date())
+  },
+  (notes) => ({
+    challengeIdIndex: index('notes_challenge_id_idx').on(notes.challengeId),
+    stageIdIndex: index('notes_stage_id_idx').on(notes.stageId),
+    teamIdIndex: index('notes_team_id_idx').on(notes.teamId),
+    authorIdIndex: index('notes_author_id_idx').on(notes.authorId)
+  })
+);
+
+export const notesRelations = relations(notes, ({ one }) => ({
+  challenge: one(challenges, {
+    fields: [notes.challengeId],
+    references: [challenges.id]
+  }),
+  stage: one(stages, { fields: [notes.stageId], references: [stages.id] }),
+  team: one(teams, { fields: [notes.teamId], references: [teams.id] }),
+  author: one(users, { fields: [notes.authorId], references: [users.id] })
+}));
+
+export const insertNoteSchema = createInsertSchema(notes).omit({
+  created: true,
+  updated: true
+});
+
+export const updateNoteSchema = createInsertSchema(notes).omit({
+  created: true,
+  updated: true
+});
+
+export type NoteType = typeof notes.$inferSelect;

--- a/lib/db/schema/resources.ts
+++ b/lib/db/schema/resources.ts
@@ -1,0 +1,51 @@
+import { index, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+import { relations, sql } from 'drizzle-orm';
+
+import { challenges } from './challenges';
+import { createInsertSchema } from 'drizzle-zod';
+
+export const resources = pgTable(
+  'resources',
+  {
+    resourceId: text('resource_id')
+      .primaryKey()
+      .notNull()
+      .default(sql`gen_random_uuid()`),
+    challengeId: text('challenge_id').references(() => challenges.id),
+    title: text('title').notNull(),
+    url: text('url'),
+    resourceType: text('resource_type').notNull(), // "sponsor", "document", "tool", etc.
+    description: text('description'),
+    created: timestamp('created', { precision: 6, withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updated: timestamp('updated', { precision: 6, withTimezone: true })
+      .defaultNow()
+      .notNull()
+      .$onUpdate(() => new Date())
+  },
+  (resources) => ({
+    challengeIdIndex: index('resources_challenge_id_idx').on(
+      resources.challengeId
+    )
+  })
+);
+
+export const resourcesRelations = relations(resources, ({ one }) => ({
+  challenge: one(challenges, {
+    fields: [resources.challengeId],
+    references: [challenges.id]
+  })
+}));
+
+export const insertResourceSchema = createInsertSchema(resources).omit({
+  created: true,
+  updated: true
+});
+
+export const updateResourceSchema = createInsertSchema(resources).omit({
+  created: true,
+  updated: true
+});
+
+export type ResourceType = typeof resources.$inferSelect;

--- a/lib/db/schema/stages.ts
+++ b/lib/db/schema/stages.ts
@@ -1,0 +1,57 @@
+import { index, integer, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+
+import { challenges } from './challenges';
+import { createInsertSchema } from 'drizzle-zod';
+import { notes } from './notes';
+import { relations } from 'drizzle-orm';
+import { sql } from 'drizzle-orm';
+import { tasks } from './tasks';
+
+export const stages = pgTable(
+  'stages',
+  {
+    id: text('id')
+      .primaryKey()
+      .notNull()
+      .default(sql`gen_random_uuid()`),
+    challengeId: text('challenge_id')
+      .notNull()
+      .references(() => challenges.id),
+    name: text('name').notNull(),
+    description: text('description'),
+    durationMinutes: integer('duration_minutes'), // Optional time limit in minutes
+    order: integer('order').notNull().default(0), // To track order of stages
+    created: timestamp('created', { precision: 6, withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updated: timestamp('updated', { precision: 6, withTimezone: true })
+      .defaultNow()
+      .notNull()
+      .$onUpdate(() => new Date())
+  },
+  (stages) => ({
+    challengeIdIndex: index('stages_challenge_id_idx').on(stages.challengeId),
+    orderIndex: index('stages_order_idx').on(stages.order)
+  })
+);
+
+export const stagesRelations = relations(stages, ({ many, one }) => ({
+  challenge: one(challenges, {
+    fields: [stages.challengeId],
+    references: [challenges.id]
+  }),
+  notes: many(notes),
+  tasks: many(tasks)
+}));
+
+export const insertStageSchema = createInsertSchema(stages).omit({
+  created: true,
+  updated: true
+});
+
+export const updateStageSchema = createInsertSchema(stages).omit({
+  created: true,
+  updated: true
+});
+
+export type StageType = typeof stages.$inferSelect;

--- a/lib/db/schema/submissions.ts
+++ b/lib/db/schema/submissions.ts
@@ -1,0 +1,75 @@
+import {
+  index,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex
+} from 'drizzle-orm/pg-core';
+import { relations, sql } from 'drizzle-orm';
+
+import { challenges } from './challenges';
+import { createInsertSchema } from 'drizzle-zod';
+import { teams } from './teams';
+import { users } from './users';
+
+// Submissions Table
+export const submissions = pgTable(
+  'submissions',
+  {
+    id: text('id')
+      .primaryKey()
+      .notNull()
+      .default(sql`gen_random_uuid()`),
+    challengeId: text('challenge_id')
+      .notNull()
+      .references(() => challenges.id),
+    teamId: text('team_id').references(() => teams.id),
+    userId: text('user_id').references(() => users.id),
+    submissionTitle: text('submission_title').notNull(),
+    description: text('description'),
+    repoLink: text('repo_link'),
+    videoLink: text('video_link'),
+    submittedAt: timestamp('submitted_at', { precision: 6, withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    created: timestamp('created', { precision: 6, withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updated: timestamp('updated', { precision: 6, withTimezone: true })
+      .defaultNow()
+      .notNull()
+      .$onUpdate(() => new Date())
+  },
+  (submissions) => ({
+    challengeIdIndex: index('submissions_challenge_id_idx').on(
+      submissions.challengeId
+    ),
+    teamIdIndex: index('submissions_team_id_idx').on(submissions.teamId),
+    userIdIndex: index('submissions_user_id_idx').on(submissions.userId),
+    uniqueChallengeTeamIndex: uniqueIndex(
+      'submissions_challenge_team_unique'
+    ).on(submissions.challengeId, submissions.teamId)
+  })
+);
+
+export const submissionsRelations = relations(submissions, ({ many, one }) => ({
+  challenge: one(challenges, {
+    fields: [submissions.challengeId],
+    references: [challenges.id]
+  }),
+  tags: many(submissions),
+  team: one(teams, { fields: [submissions.teamId], references: [teams.id] }),
+  user: one(users, { fields: [submissions.userId], references: [users.id] })
+}));
+
+export const insertSubmissionSchema = createInsertSchema(submissions).omit({
+  created: true,
+  updated: true
+});
+
+export const updateSubmissionSchema = createInsertSchema(submissions).omit({
+  created: true,
+  updated: true
+});
+
+export type SubmissionType = typeof submissions.$inferSelect;

--- a/lib/db/schema/tags-challenges.ts
+++ b/lib/db/schema/tags-challenges.ts
@@ -1,0 +1,52 @@
+import {
+  index,
+  pgTable,
+  primaryKey,
+  text,
+  timestamp
+} from 'drizzle-orm/pg-core';
+
+import { challenges } from './challenges';
+import { relations } from 'drizzle-orm';
+import { tags } from './tags';
+
+export const tagsChallenges = pgTable(
+  'tags_challenges',
+  {
+    challengeId: text('challenge_id')
+      .references(() => challenges.id)
+      .notNull(),
+    tagId: text('tag_id')
+      .references(() => tags.tagId)
+      .notNull(),
+    created: timestamp('created', { precision: 6, withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updated: timestamp('updated', { precision: 6, withTimezone: true })
+      .defaultNow()
+      .notNull()
+      .$onUpdate(() => new Date())
+  },
+  (tagsChallenges) => ({
+    pk: primaryKey({
+      columns: [tagsChallenges.challengeId, tagsChallenges.tagId]
+    }),
+    challengeIdIndex: index('tags_challenges_challenge_id_idx').on(
+      tagsChallenges.challengeId
+    ),
+    tagIdIndex: index('tags_challenges_tag_id_idx').on(tagsChallenges.tagId)
+  })
+);
+
+export const tagsChallengesRelations = relations(tagsChallenges, ({ one }) => ({
+  challenge: one(challenges, {
+    fields: [tagsChallenges.challengeId],
+    references: [challenges.id]
+  }),
+  tag: one(tags, {
+    fields: [tagsChallenges.tagId],
+    references: [tags.tagId]
+  })
+}));
+
+export type ChallengeTagType = typeof tagsChallenges.$inferSelect;

--- a/lib/db/schema/tags-submissions.ts
+++ b/lib/db/schema/tags-submissions.ts
@@ -1,0 +1,55 @@
+import {
+  index,
+  pgTable,
+  primaryKey,
+  text,
+  timestamp
+} from 'drizzle-orm/pg-core';
+
+import { relations } from 'drizzle-orm';
+import { submissions } from './submissions';
+import { tags } from './tags';
+
+export const tagsSubmissions = pgTable(
+  'tags_submissions',
+  {
+    submissionId: text('submission_id')
+      .references(() => submissions.id)
+      .notNull(),
+    tagId: text('tag_id')
+      .references(() => tags.tagId)
+      .notNull(),
+    created: timestamp('created', { precision: 6, withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updated: timestamp('updated', { precision: 6, withTimezone: true })
+      .defaultNow()
+      .notNull()
+      .$onUpdate(() => new Date())
+  },
+  (tagsSubmissions) => ({
+    pk: primaryKey({
+      columns: [tagsSubmissions.submissionId, tagsSubmissions.tagId]
+    }),
+    submissionIdIndex: index('tags_submissions_submission_id_idx').on(
+      tagsSubmissions.submissionId
+    ),
+    tagIdIndex: index('tags_submissions_tag_id_idx').on(tagsSubmissions.tagId)
+  })
+);
+
+export const tagsSubmissionsRelations = relations(
+  tagsSubmissions,
+  ({ one }) => ({
+    submission: one(submissions, {
+      fields: [tagsSubmissions.submissionId],
+      references: [submissions.id]
+    }),
+    tag: one(tags, {
+      fields: [tagsSubmissions.tagId],
+      references: [tags.tagId]
+    })
+  })
+);
+
+export type SubmissionTagType = typeof tagsSubmissions.$inferSelect;

--- a/lib/db/schema/tags.ts
+++ b/lib/db/schema/tags.ts
@@ -1,0 +1,43 @@
+import { pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+import { relations, sql } from 'drizzle-orm';
+
+import { createInsertSchema } from 'drizzle-zod';
+import { tagsChallenges } from './tags-challenges';
+import { tagsSubmissions } from './tags-submissions';
+
+export const tags = pgTable('tags', {
+  tagId: text('tag_id')
+    .primaryKey()
+    .notNull()
+    .default(sql`gen_random_uuid()`),
+  name: text('name').notNull().unique(),
+  description: text('description'),
+  created: timestamp('created', { precision: 6, withTimezone: true })
+    .defaultNow()
+    .notNull(),
+  updated: timestamp('updated', { precision: 6, withTimezone: true })
+    .defaultNow()
+    .notNull()
+    .$onUpdate(() => new Date())
+});
+
+export const tagsRelations = relations(tags, ({ many }) => ({
+  challengeTags: many(tagsChallenges),
+  submissionTags: many(tagsSubmissions)
+}));
+
+export const insertTagSchema = createInsertSchema(tags, {
+  name: (schema) => schema.name.trim().toLowerCase()
+}).omit({
+  created: true,
+  updated: true
+});
+
+export const updateTagSchema = createInsertSchema(tags, {
+  name: (schema) => schema.name.trim().toLowerCase()
+}).omit({
+  created: true,
+  updated: true
+});
+
+export type TagType = typeof tags.$inferSelect;

--- a/lib/db/schema/tasks.ts
+++ b/lib/db/schema/tasks.ts
@@ -1,0 +1,64 @@
+import { index, integer, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+
+import { createInsertSchema } from 'drizzle-zod';
+import { relations } from 'drizzle-orm';
+import { sql } from 'drizzle-orm';
+import { stages } from './stages';
+import { teams } from './teams';
+import { users } from './users';
+
+export const tasks = pgTable(
+  'tasks',
+  {
+    id: text('id')
+      .primaryKey()
+      .notNull()
+      .default(sql`gen_random_uuid()`),
+    stageId: text('stage_id')
+      .notNull()
+      .references(() => stages.id),
+    teamId: text('team_id').references(() => teams.id),
+    assignedTo: text('assigned_to').references(() => users.id),
+    estimateMinutes: integer('estimate_minutes').default(0),
+    taskName: text('task_name').notNull(),
+    status: text('status').notNull().default('not_started'), // "not_started", "in_progress", "completed"
+    dueDate: timestamp('due_date', { precision: 6, withTimezone: true }),
+    completedAt: timestamp('completed_at', {
+      precision: 6,
+      withTimezone: true
+    }),
+    created: timestamp('created', { precision: 6, withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updated: timestamp('updated', { precision: 6, withTimezone: true })
+      .defaultNow()
+      .notNull()
+      .$onUpdate(() => new Date())
+  },
+  (tasks) => ({
+    stageIdIndex: index('tasks_stage_id_idx').on(tasks.stageId),
+    teamIdIndex: index('tasks_team_id_idx').on(tasks.teamId),
+    assignedToIndex: index('tasks_assigned_to_idx').on(tasks.assignedTo)
+  })
+);
+
+export const tasksRelations = relations(tasks, ({ one }) => ({
+  stage: one(stages, { fields: [tasks.stageId], references: [stages.id] }),
+  team: one(teams, { fields: [tasks.teamId], references: [teams.id] }),
+  assignee: one(users, {
+    fields: [tasks.assignedTo],
+    references: [users.id]
+  })
+}));
+
+export const insertTaskSchema = createInsertSchema(tasks).omit({
+  created: true,
+  updated: true
+});
+
+export const updateTaskSchema = createInsertSchema(tasks).omit({
+  created: true,
+  updated: true
+});
+
+export type TaskType = typeof tasks.$inferSelect;

--- a/lib/db/schema/teams.ts
+++ b/lib/db/schema/teams.ts
@@ -1,0 +1,80 @@
+import {
+  index,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex
+} from 'drizzle-orm/pg-core';
+
+import { challenges } from './challenges';
+import { createInsertSchema } from 'drizzle-zod';
+import { fileStorage } from './file-storage';
+import { notes } from './notes';
+import { relations } from 'drizzle-orm';
+import { sql } from 'drizzle-orm';
+import { submissions } from './submissions';
+import { tasks } from './tasks';
+import { users } from './users';
+
+export const teams = pgTable(
+  'teams',
+  {
+    id: text('id')
+      .primaryKey()
+      .notNull()
+      .default(sql`gen_random_uuid()`),
+    name: text('name').notNull(),
+    joinedAt: timestamp('joined_at', { precision: 6, withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    teamRole: text('team_role'), // E.g., "developer", "designer"
+    challengeId: text('challenge_id')
+      .notNull()
+      .references(() => challenges.id),
+    teamLeadId: text('team_lead_id')
+      .notNull()
+      .references(() => users.id),
+    created: timestamp('created', { precision: 6, withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updated: timestamp('updated', { precision: 6, withTimezone: true })
+      .defaultNow()
+      .notNull()
+      .$onUpdate(() => new Date())
+  },
+  (teams) => ({
+    challengeIdIndex: index('teams_challenge_id_idx').on(teams.challengeId),
+    teamLeadIdIndex: index('teams_team_lead_id_idx').on(teams.teamLeadId),
+    uniqueTeamNamePerChallenge: uniqueIndex(
+      'unique_team_name_per_challenge'
+    ).on(teams.challengeId, teams.name)
+  })
+);
+
+export const teamsRelations = relations(teams, ({ one, many }) => ({
+  challenge: one(challenges, {
+    fields: [teams.challengeId],
+    references: [challenges.id]
+  }),
+  files: many(fileStorage),
+  members: many(users),
+  notes: many(notes),
+  submission: one(submissions, {
+    fields: [teams.id],
+    references: [submissions.teamId]
+  }),
+  tasks: many(tasks),
+  teamLead: one(users, { fields: [teams.teamLeadId], references: [users.id] })
+}));
+
+export const insertTeamSchema = createInsertSchema(teams).omit({
+  created: true,
+  updated: true
+});
+
+export const updateTeamSchema = createInsertSchema(teams).omit({
+  created: true,
+  updated: true
+});
+
+export type TeamType = typeof teams.$inferSelect;

--- a/lib/db/schema/users.ts
+++ b/lib/db/schema/users.ts
@@ -1,7 +1,14 @@
 import { pgTable, text, timestamp, varchar } from 'drizzle-orm/pg-core';
 
+import { challenges } from './challenges';
 import { createInsertSchema } from 'drizzle-zod';
+import { fileStorage } from './file-storage';
+import { notes } from './notes';
+import { relations } from 'drizzle-orm';
 import { sql } from 'drizzle-orm';
+import { submissions } from './submissions';
+import { tasks } from './tasks';
+import { teams } from './teams';
 
 export const users = pgTable('users', {
   id: text('id')
@@ -21,6 +28,18 @@ export const users = pgTable('users', {
     .notNull()
     .$onUpdate(() => new Date())
 });
+
+export const usersRelations = relations(users, ({ many, one }) => ({
+  challenges: many(challenges),
+  files: many(fileStorage),
+  notes: many(notes),
+  submission: one(submissions, {
+    fields: [users.id],
+    references: [submissions.userId]
+  }),
+  tasks: many(tasks),
+  teams: many(teams)
+}));
 
 export const insertUserSchema = createInsertSchema(users, {
   email: (schema) => schema.email.trim().toLowerCase()


### PR DESCRIPTION
This pull request adds the core models to the database. It includes the following changes:

- A new column "public" is added to the "challenges" table.

- The "users" table is updated to include relationships with other tables such as "challenges", "fileStorage", "notes", "submissions", "tasks", and "teams".

- New tables "tags", "tagsChallenges", "tagsSubmissions", "resources", "events", and "stages" are added to the database, along with their respective relationships with other tables.

- Insert and update schemas are created for the new tables.

- Various indexes are added to improve performance.